### PR TITLE
refactor: impl counter based event buffer

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -822,7 +822,8 @@ export const makeChatsSocket = (config: SocketConfig) => {
 			// we keep buffering events until we finally have
 			// the key and can sync the messages
 			if(!authState.creds?.myAppStateKeyId) {
-				needToFlushWithAppStateSync = ev.buffer()
+				ev.buffer()
+				needToFlushWithAppStateSync = true
 			}
 		}
 	})

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -645,33 +645,15 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		identifier: string,
 		exec: (node: BinaryNode) => Promise<any>
 	) => {
-		const started = ev.buffer()
-		if(started) {
-			await execTask()
-			if(started) {
-				await ev.flush()
-			}
-		} else {
-			const task = execTask()
-			ev.processInBuffer(task)
-		}
+		ev.buffer()
+		await execTask()
+		ev.flush()
 
 		function execTask() {
 			return exec(node)
 				.catch(err => onUnexpectedError(err, identifier))
 		}
 	}
-
-	// called when all offline notifs are handled
-	ws.on('CB:ib,,offline', async(node: BinaryNode) => {
-		const child = getBinaryNodeChild(node, 'offline')
-		const offlineNotifs = +(child?.attrs.count || 0)
-
-		logger.info(`handled ${offlineNotifs} offline messages/notifications`)
-		await ev.flush()
-
-		ev.emit('connection.update', { receivedPendingNotifications: true })
-	})
 
 	// recv a message
 	ws.on('CB:message', (node: BinaryNode) => {

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -532,15 +532,32 @@ export const makeSocket = ({
 		end(new Boom('Multi-device beta not joined', { statusCode: DisconnectReason.multideviceMismatch }))
 	})
 
+	let didStartBuffer = false
 	process.nextTick(() => {
 		if(creds.me?.id) {
 			// start buffering important events
 			// if we're logged in
 			ev.buffer()
+			didStartBuffer = true
 		}
 
 		ev.emit('connection.update', { connection: 'connecting', receivedPendingNotifications: false, qr: undefined })
 	})
+
+	// called when all offline notifs are handled
+	ws.on('CB:ib,,offline', (node: BinaryNode) => {
+		const child = getBinaryNodeChild(node, 'offline')
+		const offlineNotifs = +(child?.attrs.count || 0)
+
+		logger.info(`handled ${offlineNotifs} offline messages/notifications`)
+		if(didStartBuffer) {
+			ev.flush()
+			logger.trace('flushed events for initial buffer')
+		}
+
+		ev.emit('connection.update', { receivedPendingNotifications: true })
+	})
+
 	// update credentials when required
 	ev.on('creds.update', update => {
 		const name = update.me?.name

--- a/src/Tests/test.event-buffer.ts
+++ b/src/Tests/test.event-buffer.ts
@@ -22,16 +22,25 @@ describe('Event Buffer Tests', () => {
 		ev.on('chats.update', () => fail('should not emit update event'))
 
 		ev.buffer()
-		ev.processInBuffer((async() => {
-			await delay(100)
-			ev.emit('chats.upsert', [{ id: chatId, conversationTimestamp: 123, unreadCount: 1 }])
-		})())
-		ev.processInBuffer((async() => {
-			await delay(200)
-			ev.emit('chats.update', [{ id: chatId, conversationTimestamp: 124, unreadCount: 1 }])
-		})())
+		await Promise.all([
+			(async() => {
+				ev.buffer()
+				await delay(100)
+				ev.emit('chats.upsert', [{ id: chatId, conversationTimestamp: 123, unreadCount: 1 }])
+				const flushed = ev.flush()
+				expect(flushed).toBeFalsy()
+			})(),
+			(async() => {
+				ev.buffer()
+				await delay(200)
+				ev.emit('chats.update', [{ id: chatId, conversationTimestamp: 124, unreadCount: 1 }])
+				const flushed = ev.flush()
+				expect(flushed).toBeFalsy()
+			})()
+		])
 
-		await ev.flush()
+		const flushed = ev.flush()
+		expect(flushed).toBeTruthy()
 
 		expect(chats).toHaveLength(1)
 		expect(chats[0].conversationTimestamp).toEqual(124)
@@ -51,7 +60,7 @@ describe('Event Buffer Tests', () => {
 		ev.emit('chats.delete', [chatId])
 		ev.emit('chats.update', [{ id: chatId, conversationTimestamp: 124, unreadCount: 1 }])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(chats).toHaveLength(1)
 	})
@@ -68,7 +77,7 @@ describe('Event Buffer Tests', () => {
 		ev.emit('chats.update', [{ id: chatId, conversationTimestamp: 123, unreadCount: 1 }])
 		ev.emit('chats.delete', [chatId])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(chatsDeleted).toHaveLength(1)
 	})
@@ -103,7 +112,7 @@ describe('Event Buffer Tests', () => {
 			}
 		}])
 
-		await ev.flush()
+		ev.flush()
 
 		ev.buffer()
 		ev.emit('chats.upsert', [{
@@ -123,7 +132,7 @@ describe('Event Buffer Tests', () => {
 			messages: [],
 			isLatest: false
 		})
-		await ev.flush()
+		ev.flush()
 
 		expect(chatsUpserted).toHaveLength(1)
 		expect(chatsUpserted[0].id).toEqual(chatId)
@@ -159,7 +168,7 @@ describe('Event Buffer Tests', () => {
 			muteEndTime: 123
 		}])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(chatsUpserted).toHaveLength(1)
 		expect(chatsUpserted[0].archived).toBeUndefined()
@@ -184,7 +193,7 @@ describe('Event Buffer Tests', () => {
 		})
 		ev.emit('chats.update', [{ id: chatId, archived: true }])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(chatRecv).toBeDefined()
 		expect(chatRecv?.archived).toBeTruthy()
@@ -218,7 +227,7 @@ describe('Event Buffer Tests', () => {
 		ev.emit('messages.upsert', { messages: [proto.WebMessageInfo.fromObject(msg)], type: 'notify' })
 		ev.emit('messages.update', [{ key: msg.key, update: { status: WAMessageStatus.READ } }])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(msgs).toHaveLength(1)
 		expect(msgs[0].message).toBeTruthy()
@@ -254,7 +263,7 @@ describe('Event Buffer Tests', () => {
 			}
 		])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(msgs).toHaveLength(1)
 		expect(msgs[0].userReceipt).toHaveLength(1)
@@ -275,7 +284,7 @@ describe('Event Buffer Tests', () => {
 		ev.emit('messages.update', [{ key, update: { status: WAMessageStatus.DELIVERY_ACK } }])
 		ev.emit('messages.update', [{ key, update: { status: WAMessageStatus.READ } }])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(msgs).toHaveLength(1)
 		expect(msgs[0].update.status).toEqual(WAMessageStatus.READ)
@@ -303,39 +312,8 @@ describe('Event Buffer Tests', () => {
 		ev.emit('chats.update', [{ id: msg.key.remoteJid!, unreadCount: 1, conversationTimestamp: msg.messageTimestamp }])
 		ev.emit('messages.update', [{ key: msg.key, update: { status: WAMessageStatus.READ } }])
 
-		await ev.flush()
+		ev.flush()
 
 		expect(chats[0].unreadCount).toBeUndefined()
-	})
-
-	it('should not deadlock', async() => {
-		const bufferedCode = ev.createBufferedFunction(
-			async() => {
-
-			}
-		)
-		ev.buffer()
-
-		let resolve: (() => void) | undefined
-		const initPromise = new Promise<void>(r => {
-			resolve = r
-		})
-		ev.processInBuffer(initPromise)
-		const flushPromise = ev.flush()
-
-		ev.processInBuffer(
-			(async() => {
-				await initPromise
-				await delay(100)
-				await bufferedCode()
-			})()
-		)
-
-		resolve!()
-
-		await flushPromise
-
-		// should resolve
-		await ev.flush()
 	})
 })


### PR DESCRIPTION
1. counter based event buffer keeps track of the number of blocks that request event processing in buffer
2. event buffer only releases events when the last block completes (i.e. counter = 0)

this approach is far simpler than the promised based garbled crap I wrote, should also prevent the deadlock issues it introduced 🙏